### PR TITLE
Fix version file

### DIFF
--- a/MSP3000a.version
+++ b/MSP3000a.version
@@ -13,7 +13,7 @@
     "MINOR": 8,
     "PATCH": 1
   },
-  "KSP_VERSION_MIN": {
+  "KSP_VERSION_MAX": {
     "MAJOR": 1,
     "MINOR": 12,
     "PATCH": 99


### PR DESCRIPTION
Hi @linuxgurugamer,

This mod's version file has a `KSP_VERSION_MIN` of 1.12.99, which is greater than any actual game version and matches none.

This PR changes it to `KSP_VERSION_MAX` so it can potentially be used by CKAN.

Cheers!
